### PR TITLE
feat: ファイルサーバーのhostnameを動的に設定可能にする

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,3 +13,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "EagleFeederAnimatedWebp": "EagleFeeder (AnimatedWEBP)",
     "EagleFeederMp4": "EagleFeeder (MP4)",
 }
+
+WEB_DIRECTORY = "./web/js"

--- a/api/eagle_api.py
+++ b/api/eagle_api.py
@@ -18,10 +18,10 @@ class EagleAPI:
             logger.error(response.text)
         return response.json()["data"]
 
-    def add_from_url(self, file_name: str, tag_list: list[str], folder_id: str) -> None:
+    def add_from_url(self, file_name: str, tag_list: list[str], folder_id: str, file_server_host: str = "localhost") -> None:
         url = self.base_url + "/item/addFromURL"
         headers = {"Content-Type": "application/json"}
-        src_url = f"http://localhost:{FILE_SERVER_PORT}/{file_name}"
+        src_url = f"http://{file_server_host}:{FILE_SERVER_PORT}/{file_name}"
         json = {
             "url": src_url,
             "name": file_name,

--- a/nodes/eagle_feeder_animated_webp.py
+++ b/nodes/eagle_feeder_animated_webp.py
@@ -19,6 +19,7 @@ class EagleFeederAnimatedWebp(EagleFeederBase):
                 "folder_name": ("STRING", {"default": ""}),
                 "eagle_host": ("STRING", {"default": "http://localhost:41595"}),
                 "eagle_token": ("STRING", {"default": ""}),
+                "file_server_host": ("STRING", {"default": "localhost"}),
                 "embed_workflow": ("BOOLEAN", {"default": True}),
                 "fps": (
                     "FLOAT",
@@ -38,6 +39,7 @@ class EagleFeederAnimatedWebp(EagleFeederBase):
         folder_name: str,
         eagle_host: str,
         eagle_token: str,
+        file_server_host: str,
         embed_workflow: bool,
         fps: float,
         lossless: bool,
@@ -83,6 +85,6 @@ class EagleFeederAnimatedWebp(EagleFeederBase):
             )
 
         tag_list = tags.split(",")
-        self.eagle_api.add_from_url(file_name, tag_list, folder_id)
+        self.eagle_api.add_from_url(file_name, tag_list, folder_id, file_server_host)
 
         return {}

--- a/nodes/eagle_feeder_mp4.py
+++ b/nodes/eagle_feeder_mp4.py
@@ -16,6 +16,7 @@ class EagleFeederMp4(EagleFeederBase):
                 "folder_name": ("STRING", {"default": ""}),
                 "eagle_host": ("STRING", {"default": "http://localhost:41595"}),
                 "eagle_token": ("STRING", {"default": ""}),
+                "file_server_host": ("STRING", {"default": "localhost"}),
                 "embed_workflow": ("BOOLEAN", {"default": True}),
                 "format": (VideoContainer.as_input(), {"default": "auto"}),
                 "codec": (VideoCodec.as_input(), {"default": "auto"}),
@@ -30,6 +31,7 @@ class EagleFeederMp4(EagleFeederBase):
         folder_name: str,
         eagle_host: str,
         eagle_token: str,
+        file_server_host: str,
         embed_workflow: bool,
         format: str,
         codec: str,
@@ -53,6 +55,6 @@ class EagleFeederMp4(EagleFeederBase):
         video.save_to(file_path, format=format, codec=codec, metadata=metadata)
 
         tag_list = tags.split(",")
-        self.eagle_api.add_from_url(file_name, tag_list, folder_id)
+        self.eagle_api.add_from_url(file_name, tag_list, folder_id, file_server_host)
 
         return {}

--- a/nodes/eagle_feeder_png.py
+++ b/nodes/eagle_feeder_png.py
@@ -18,6 +18,7 @@ class EagleFeederPng(EagleFeederBase):
                 "folder_name": ("STRING", {"default": ""}),
                 "eagle_host": ("STRING", {"default": "http://localhost:41595"}),
                 "eagle_token": ("STRING", {"default": ""}),
+                "file_server_host": ("STRING", {"default": "localhost"}),
                 "embed_workflow": ("BOOLEAN", {"default": True}),
             },
             "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"},
@@ -32,6 +33,7 @@ class EagleFeederPng(EagleFeederBase):
         folder_name: list[str],
         eagle_host: list[str],
         eagle_token: list[str],
+        file_server_host: list[str],
         embed_workflow: list[bool],
         prompt: list,
         extra_pnginfo: list,
@@ -40,6 +42,7 @@ class EagleFeederPng(EagleFeederBase):
         folder_name = folder_name[0]
         eagle_host = eagle_host[0]
         eagle_token = eagle_token[0]
+        file_server_host = file_server_host[0]
         embed_workflow = embed_workflow[0]
         prompt = prompt[0]
         extra_pnginfo = extra_pnginfo[0]
@@ -67,6 +70,6 @@ class EagleFeederPng(EagleFeederBase):
                 image.save(file_path, format="PNG")
 
             tag_list = tags[idx].split(",")
-            self.eagle_api.add_from_url(file_name, tag_list, folder_id)
+            self.eagle_api.add_from_url(file_name, tag_list, folder_id, file_server_host)
 
         return {}

--- a/tests/test_eagle_api.py
+++ b/tests/test_eagle_api.py
@@ -1,0 +1,42 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ルートの __init__.py を経由せずに api/eagle_api.py を直接ロードする
+_eagle_api_path = Path(__file__).resolve().parents[1] / "api" / "eagle_api.py"
+_spec = importlib.util.spec_from_file_location("eagle_api", _eagle_api_path)
+eagle_api_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(eagle_api_mod)
+
+EagleAPI = eagle_api_mod.EagleAPI
+FILE_SERVER_PORT = eagle_api_mod.FILE_SERVER_PORT
+
+
+class TestAddFromUrl(unittest.TestCase):
+    def setUp(self):
+        self.api = EagleAPI.__new__(EagleAPI)
+        self.api.base_url = "http://localhost:41595/api"
+        self.api.token = "test-token"
+
+    @patch.object(eagle_api_mod.requests, "post")
+    def test_uses_custom_host(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+
+        self.api.add_from_url("test.png", ["tag1"], "folder1", file_server_host="hira-win")
+
+        called_json = mock_post.call_args[1]["json"]
+        self.assertEqual(called_json["url"], f"http://hira-win:{FILE_SERVER_PORT}/test.png")
+
+    @patch.object(eagle_api_mod.requests, "post")
+    def test_uses_default_localhost(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+
+        self.api.add_from_url("test.png", ["tag1"], "folder1")
+
+        called_json = mock_post.call_args[1]["json"]
+        self.assertEqual(called_json["url"], f"http://localhost:{FILE_SERVER_PORT}/test.png")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/eagle_feeder_defaults.js
+++ b/web/js/eagle_feeder_defaults.js
@@ -1,0 +1,25 @@
+import { app } from "../../scripts/app.js";
+
+const TARGET_NODE_TYPES = [
+    "EagleFeederPng",
+    "EagleFeederAnimatedWebp",
+    "EagleFeederMp4",
+];
+
+app.registerExtension({
+    name: "comfyui-eagle-feeder.defaults",
+
+    nodeCreated(node) {
+        if (!TARGET_NODE_TYPES.includes(node.comfyClass)) {
+            return;
+        }
+
+        const widget = node.widgets?.find((w) => w.name === "file_server_host");
+        if (widget && widget.value === "localhost") {
+            const hostname = window.location.hostname;
+            if (hostname && hostname !== "" && hostname !== "localhost") {
+                widget.value = hostname;
+            }
+        }
+    },
+});


### PR DESCRIPTION
ファイルサーバーのURLが localhost にハードコードされていたため、
リモートPC間でEagleへの画像転送が失敗する問題を修正。
ブラウザのhostnameをデフォルト値として自動設定しつつ、
ノード上で上書き可能な file_server_host 入力を追加。